### PR TITLE
Add `java.lang.Object` back to `ClassInfo` cache

### DIFF
--- a/src/main/java/ca/fxco/memoryleakfix/memoryLeakFix.java
+++ b/src/main/java/ca/fxco/memoryleakfix/memoryLeakFix.java
@@ -53,7 +53,8 @@ public class memoryLeakFix implements ModInitializer {
             return; // Crashes crafty crashes if it crashes
         Field cacheField = ClassInfo.class.getDeclaredField("cache");
         cacheField.setAccessible(true);
-        Map<?, ?> cache = ((Map<?, ?>)cacheField.get(null));
+        @SuppressWarnings("unchecked")
+        Map<String, ClassInfo> cache = ((Map<String, ClassInfo>)cacheField.get(null));
         ClassInfo jlo = cache.get(OBJECT);
         cache.clear();
         cache.put(OBJECT, jlo);

--- a/src/main/java/ca/fxco/memoryleakfix/memoryLeakFix.java
+++ b/src/main/java/ca/fxco/memoryleakfix/memoryLeakFix.java
@@ -45,12 +45,17 @@ public class memoryLeakFix implements ModInitializer {
             e.printStackTrace();
         }
     }
+    
+    private static final String OBJECT = "java/lang/Object";
 
     private static void emptyClassInfo() throws NoSuchFieldException, IllegalAccessException {
         if (FabricLoader.getInstance().isModLoaded("not-that-cc"))
             return; // Crashes crafty crashes if it crashes
         Field cacheField = ClassInfo.class.getDeclaredField("cache");
         cacheField.setAccessible(true);
-        ((Map<?, ?>)cacheField.get(null)).clear();
+        Map<?, ?> cache = ((Map<?, ?>)cacheField.get(null));
+        ClassInfo jlo = cache.get(OBJECT);
+        cache.clear();
+        cache.put(OBJECT, jlo);
     }
 }


### PR DESCRIPTION
Mixin puts it manually and it even has its own constructor, I'm assuming it needs special casing and it's why there's stack overflows when somehow a mixin is applied later. That still shouldn't happen, but this should prevent the crashes in exchange of populating a bit of the cache back.

This doesn't fix the issue in #5 (or I don't think it should?), only the crash from the second user in the same issue (probably).

Note that I've written this in Github's web editor so it may not be correct, and it has had no testing.