### PR TITLE
Remove ForgetMeChunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ### A mod that fixes multiple memory leaks in minecraft. Both server-side & client-side  
   
 For the best performance & memory usage, I recommend using this mod with:  
-- [ForgetMeChunk](https://github.com/mjwells2002/ForgetMeChunk) - Fixes the chunk border lag spikes, basically required if you want smooth gameplay!  
 - [lazydfu](https://github.com/astei/lazydfu) - Makes startup much faster by not loading DFU until needed, also saves on memory  
 - [lithium-fabric](https://github.com/CaffeineMC/lithium-fabric) - The best general performance mod  
 - [starlight](https://github.com/PaperMC/Starlight) - Re-write of the light engine to be blazing fast  


### PR DESCRIPTION
I say it should be removed since it causes memory leaks, which is counter-productive to the benefits given by the fix. This results in the heap becoming crammed, causing unplayable experience as the heap reaches a point where there is no room left.