### PR TITLE
set maxVersion for TextureUtil mixin

### DIFF
--- a/common/src/main/java/ca/fxco/memoryleakfix/mixin/readResourcesLeak/TextureUtil_freeBuffer_MojangPackageMixin.java
+++ b/common/src/main/java/ca/fxco/memoryleakfix/mixin/readResourcesLeak/TextureUtil_freeBuffer_MojangPackageMixin.java
@@ -17,7 +17,7 @@ import java.nio.channels.Channel;
 
 @MinecraftRequirement({
         @VersionRange(maxVersion = "1.14.4"),
-        @VersionRange(minVersion = "1.17.0")
+        @VersionRange(minVersion = "1.17.0", maxVersion = "1.19.3")
 })
 @Environment(EnvType.CLIENT)
 @Mixin(value = TextureUtil.class, remap = false)


### PR DESCRIPTION
fixes crash on 1.19.4